### PR TITLE
Add devshell to nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ On Nix you can run:
 2.  
     ```bash
     pip install -e .
-
+    ```
 This will install llm-git-commit and all its dependencies to a python virtual environment that can be entered by running `nix develop` in the project dir.
 
 ---

--- a/README.md
+++ b/README.md
@@ -193,4 +193,16 @@ To set up this plugin locally for further development:
     ```
     Now you can modify the code, and the changes will be live when you run `llm git-commit`.
 
+On Nix you can run:
+
+1.  
+    ```bash
+    nix develop
+    ```
+2.  
+    ```bash
+    pip install -e .
+
+This will install llm-git-commit and all its dependencies to a python virtual environment that can be entered by running `nix develop` in the project dir.
+
 ---

--- a/flake.nix
+++ b/flake.nix
@@ -22,5 +22,24 @@
     packages = forAllSystems (system: import ./Nix/Packages nixpkgs.legacyPackages.${system});
 
     formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
+
+    devShell = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      myPython = pkgs.python3;
+      llm-git-commit = self.packages.${pkgs.system}.master;
+      pythonWithPkgs = myPython.withPackages (ps: [
+        ps.setuptools
+        llm-git-commit
+        ps.click
+        ps.llm
+        ps.prompt-toolkit
+        ps.llm-openrouter
+      ]);
+    in
+      pkgs.mkShell {
+        packages = [
+          pythonWithPkgs
+        ];
+      });
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,14 @@
         ];
 
         shellHook = ''
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install -e .
+          if [ ! -d "${venv}" ]; then
+            echo "Creating Python venv..."
+            python3 -m venv ${venv}
+          fi
+          echo "Activating venv..."
+          source ${venv}/bin/activate
+          echo "Installing package in editable mode..."
+          pip install -e . || echo "Warning: Failed to install package in editable mode."
         '';
       });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,6 @@
           echo "Activating venv..."
           source ${venv}/bin/activate
           echo "Installing package in editable mode..."
-          pip install -e . || echo "Warning: Failed to install package in editable mode."
         '';
       });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
           fi
           echo "Activating venv..."
           source ${venv}/bin/activate
-          echo "Installing package in editable mode..."
         '';
       });
   };

--- a/flake.nix
+++ b/flake.nix
@@ -26,20 +26,22 @@
     devShell = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       myPython = pkgs.python3;
-      llm-git-commit = self.packages.${pkgs.system}.master;
       pythonWithPkgs = myPython.withPackages (ps: [
+        ps.pip
         ps.setuptools
-        llm-git-commit
-        ps.click
-        ps.llm
-        ps.prompt-toolkit
-        ps.llm-openrouter
       ]);
+      venv = "venv";
     in
       pkgs.mkShell {
         packages = [
           pythonWithPkgs
         ];
+
+        shellHook = ''
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -e .
+        '';
       });
   };
 }


### PR DESCRIPTION
Added a devshell to the nix flake that creates a nix shell with containing a shell hook to create and activate the venv, then uses pip install -e . to install the package in editable mode. Can confirm that this works on my end and should make it easier for anyone using Nix to develop on here. Started out just with the basic create a python env with the package but I think this venv shellhook is more flexible imo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a development shell that automatically sets up and activates a Python virtual environment with necessary tools, providing a consistent Python development environment across all supported platforms.
  * Added documentation for setting up the development environment using the new Nix-based workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->